### PR TITLE
Duplicated fragment declarations

### DIFF
--- a/src/Deskpro/API/GraphQL/AbstractBuilder.php
+++ b/src/Deskpro/API/GraphQL/AbstractBuilder.php
@@ -386,7 +386,7 @@ abstract class AbstractBuilder implements BuilderInterface
                 continue;
             }
 
-            $sanitizedFragments[] = sprintf(
+            $sanitizedFragments[$field->getName()] = sprintf(
                 "fragment %s on %s {\n%s%s\n}\n",
                 $field->getName(),
                 $field->getOnType(),


### PR DESCRIPTION
When adding multiple fields with the same fragment, multiple fragment directives are inserted under the same name, while fragment name should be unique across declarations.